### PR TITLE
Profile flag

### DIFF
--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -84,6 +84,7 @@ def params():
     parser.add_argument('--compilation_config',
                         type=str,
                         help='compilation config as json string, e.g. "{\"use_inductor\": true, \"compile_sizes\": [1, 2, 4, 8]}"')
+    parser.add_argument('--profile', action='store_true', help='enable PyTorch profiler in vLLM')
 
     parser.parse_args(namespace=par)
 
@@ -246,8 +247,12 @@ def run(input_size, output_size, batch_size):
         fmwork.t0()
         #with MADProfiler(backend="rpd", nvtx_tracing=True):
         #    outputs = var.llm.generate(**kwargs)
+        if par.profile:
+            var.llm.start_profile()
         outputs = var.llm.generate(**kwargs)
         torch.cuda.synchronize()
+        if par.profile:
+            var.llm.stop_profile()
         ret = fmwork.t1(
             rep, par.reps,
             input_size, output_size, batch_size,


### PR DESCRIPTION
Add flag `--profile` for switching on https://docs.vllm.ai/en/latest/contributing/profiling/profiling_index.html#profile-with-pytorch-profiler.

One also needs to set `VLLM_TORCH_PROFILER_DIR` env variable and suitable settings in [vLLM side](https://github.com/vllm-project/vllm/blob/e7ef61c1f039a8eac98602a9e5ab7517027e7278/vllm/v1/worker/gpu_worker.py#L64-L74)