### PR TITLE
Remove num_scheduler_steps

### DIFF
--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -62,8 +62,6 @@ def params():
         type=float, default=0.95)
     parser.add_argument('-e', '--enforce_eager',
         action='store_true')
-    parser.add_argument('-s', '--num_scheduler_steps',
-        type=int, default=1)
     parser.add_argument(      '--distributed_executor_backend',
         default='mp')
     parser.add_argument('-M', '--max_num_seqs',
@@ -132,7 +130,6 @@ def llm():
         quantization                 = par.quantization,
         tensor_parallel_size         = par.tensor_parallel,
         trust_remote_code            = True,
-        num_scheduler_steps          = par.num_scheduler_steps,
         distributed_executor_backend = par.distributed_executor_backend,
         max_num_seqs                 = par.max_num_seqs,
         enable_chunked_prefill       = par.enable_chunked_prefill,

--- a/infer/vllm/driver
+++ b/infer/vllm/driver
@@ -62,6 +62,8 @@ def params():
         type=float, default=0.95)
     parser.add_argument('-e', '--enforce_eager',
         action='store_true')
+    parser.add_argument('-s', '--num_scheduler_steps',
+        type=int, default=1) # Dummy argument, will be removed soon.
     parser.add_argument(      '--distributed_executor_backend',
         default='mp')
     parser.add_argument('-M', '--max_num_seqs',


### PR DESCRIPTION
Remove num_scheduler_steps argument. Apparently newer rocm/vllm images have removed this argument (starting from rocm/vllm-dev:nightly_main_20250814) and using it will cause an error.

With this change support for vLLM V0 workloads will be removed from fmwork (see discussion in this [ticket](https://ontrack-internal.amd.com/browse/SWDEV-549432)).